### PR TITLE
Fix hl macro to handle commas in arguments by avoiding nested macro expansion

### DIFF
--- a/org/org-macros.setup
+++ b/org/org-macros.setup
@@ -12,7 +12,7 @@
 
 #+MACRO: highlight @@html:<span style="background-color: $1;">$2</span>@@
 
-#+MACRO: hl {{{highlight(#FFFF00,$1)}}}
+#+MACRO: hl @@html:<span style="background-color: #FFFF00;">$1</span>@@
 
 #+MACRO: loremipsum Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 


### PR DESCRIPTION
The hl macro was using nested macro expansion syntax {{{highlight(...)}}} which caused Org mode to      re-parse the argument and treat commas as argument separators, resulting in text after commas being      truncated during HTML export (even when escaped). This change replaces the nested macro call with direct HTML output,      allowing the entire text including commas to be treated as a single argument and exported correctly. 